### PR TITLE
fix BrowserslistError: `browserlist` key instead of `browserslist`

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -84,7 +84,7 @@
     "node": ">= 4.0.0",
     "npm": ">= 3.0.0"
   },
-  "browserlist": [
+  "browserslist": [
     "> 1%",
     "last 2 versions",
     "not ie <= 8"


### PR DESCRIPTION
fix Module build failed: BrowserslistError: `browserlist` key instead of `browserslist`